### PR TITLE
Display local time instead of UTC

### DIFF
--- a/main_app/static/js/account.js
+++ b/main_app/static/js/account.js
@@ -1,0 +1,18 @@
+// Required to convert UTC to local time
+
+const dateJoinedEl = document.getElementById('date-joined');
+const orderedAtEls = document.querySelectorAll('.account-ordered-at');
+
+const utcText = dateJoinedEl.innerText;
+const utc_moment = moment.utc(utcText, "LLL");
+const localMoment = utc_moment.local().format('LLL');
+dateJoinedEl.innerHTML = localMoment;
+
+orderedAtEls.forEach((el) => {
+  // const utcText = el.innerText;
+  const utcText = el.childNodes[1].nodeValue; // Need to extract date text this way to ignore parent text
+  const utcMoment = moment.utc(utcText, "LLL");
+  const localMoment = utcMoment.local().format('LLL');
+  // el.innerHTML = localMoment;
+  el.childNodes[1].nodeValue = localMoment;
+});

--- a/main_app/static/js/order_detail.js
+++ b/main_app/static/js/order_detail.js
@@ -1,0 +1,7 @@
+// Required to convert UTC to local time
+
+const orderedAtEl = document.querySelector('.order-detail-ordered-at');
+const utcText = orderedAtEl.childNodes[1].nodeValue;
+const utc_moment = moment.utc(utcText, "LLL");
+const local_moment = utc_moment.local().format('LLL');
+orderedAtEl.childNodes[1].nodeValue = local_moment;

--- a/main_app/templates/account.html
+++ b/main_app/templates/account.html
@@ -55,7 +55,7 @@
       </div>
       <div class="account-details" >
         <p class="account-label">Date Joined:</p>
-        <p class="account-data"> {{ user.date_joined }}</p>
+        <p class="account-data" id="date-joined"> {{ user.date_joined }}</p>
       </div>
     </div>
   </div>
@@ -69,9 +69,9 @@
       <p>Order #: {{ cart.id }}</p>
     </div>
     <div class="order-info">
-      <p><span class="order-label">Ordered:</span> {{ cart.ordered_at }}</p>
-      <p><span class="order-label">Total:</span> ${{ cart.get_total}}</p>
-      <p><span class="order-label">Status:</span> {{ cart.get_status_display }} </p>
+      <p class="account-ordered-at"><span class="order-label">Ordered: </span>{{ cart.ordered_at }}</p>
+      <p><span class="order-label">Total: </span>${{ cart.get_total }}</p>
+      <p><span class="order-label">Status: </span>{{ cart.get_status_display }} </p>
     </div>
     <div>
       <a class="order-btn" href="{% url 'order_detail' cart.id %}">View Order</a>
@@ -79,6 +79,7 @@
   </div>
   {% endfor %}
 </div>
+<script src="{% static 'js/account.js' %}"></script>
 {% endblock %}
 
 

--- a/main_app/templates/base.html
+++ b/main_app/templates/base.html
@@ -23,6 +23,8 @@
   <link rel="stylesheet" type="text/css" href="{% static 'css/account.css' %}">
   <link rel="stylesheet" type="text/css" href="{% static 'css/cart.css' %}">
   <script src="https://kit.fontawesome.com/7344249496.js" crossorigin="anonymous"></script>
+  <!-- moment.js – For converting UTC to local time -->
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.27.0/moment.min.js" type="text/javascript"></script>
   <title>Road Star Tire</title>
 </head>
 <body>
@@ -55,6 +57,7 @@
   </header>
   <main>
     {% block content %}
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.27.0/moment.min.js" type="text/javascript"></script>
     {% endblock %}
   </main>
   <footer>

--- a/main_app/templates/order_detail.html
+++ b/main_app/templates/order_detail.html
@@ -4,14 +4,14 @@
 <div class="container-main">
   <h1>Order #: {{ order.id }}</h1>
   <div class="container-info order-detail-info">
-      <h4>Ordered: {{ order.date_ordered }}</h5>
-      <h4>Status: {{ order.get_status_display }} </h5>
-      <h5>Shipped to:</h5>
-      <p>Company Name: {{ user.company_name }}</p>
-      <p>Address: {{ user.address }}</p>
-      <p>City: {{ user.city }}</p>
-      <p>Province: {{ user.province_iso }}</p>
-      <p>Postal Code: {{ user.postal_code }}</p>
+    <h5 class="order-detail-ordered-at"><span>Ordered: </span>{{ order.ordered_at }}</h5>
+    <h5>Status: {{ order.get_status_display }} </h5>
+    <h5>Shipped to:</h5>
+    <p>Company Name: {{ user.company_name }}</p>
+    <p>Address: {{ user.address }}</p>
+    <p>City: {{ user.city }}</p>
+    <p>Province: {{ user.province_iso }}</p>
+    <p>Postal Code: {{ user.postal_code }}</p>
 
     <div class="container-cart-headers">
       <p class="cart-label">Items</p>
@@ -38,4 +38,5 @@
       {% endif %}
     </div>
 </div>
+<script src="{% static 'js/order_detail.js' %}"></script>
 {% endblock %}

--- a/users/admin.py
+++ b/users/admin.py
@@ -19,6 +19,8 @@ class CartInline(admin.TabularInline):
     'get_item_count', 
     'get_subtotal',
     'get_total',
+    'ordered_at',
+    'closed_at'
   )
 
 class CustomUserAdmin(UserAdmin):


### PR DESCRIPTION
* UTC time will continue to be stored in the database and the front-end uses JavaScript (via the `moment.js` package) to convert the UTC date to the user's local time according to their browser
* Pulling in the `moment.js` package from a CDN but could potentially have it downloaded directly into our project (I think the CDN route is easier to manage and may prove to be faster to access)