### PR TITLE
Fix 'Add to cart' button on tire_list and use of signals to update date_effective

### DIFF
--- a/main_app/admin.py
+++ b/main_app/admin.py
@@ -539,7 +539,7 @@ class TireAdmin(admin.ModelAdmin):
       old_obj = deepcopy(obj)
       obj.id = None # Set to None so that new row is inserted
       obj.inherits_from = old_obj
-      obj.date_effective = timezone.now() # Default to current time for now until can find a way to filter the tire_list queryset proprerly
+      # obj.date_effective = timezone.now() # Default to current time for now until can find a way to filter the tire_list queryset proprerly
       obj.save()
     super().save_model(request, obj, form, change)
     

--- a/main_app/signals.py
+++ b/main_app/signals.py
@@ -95,8 +95,7 @@ def update_updated_to(sender, instance, *args, **kwargs):
   if instance.inherits_from: # If beyond the first Tire version
     Tire.objects.all().filter(id=instance.inherits_from.id).update(updated_to=instance)
 
-# Update in the TireAdmin save_model instead
-# @receiver(post_save, sender=Tire)
-# def update_date_effective(sender, instance, *args, **kwargs):
-#   if not instance.date_effective_tracker.has_changed('date_effective'):
-#     Tire.objects.all().filter(pk=instance.pk).update(date_effective = timezone.now())
+@receiver(post_save, sender=Tire)
+def update_date_effective(sender, instance, *args, **kwargs):
+  if not instance.date_effective_tracker.has_changed('date_effective'):
+    Tire.objects.all().filter(pk=instance.pk).update(date_effective = timezone.now())

--- a/main_app/views.py
+++ b/main_app/views.py
@@ -426,7 +426,7 @@ def add_to_cart(req):
     }
   )
 
-  instance, created = CartDetail.objects.get_or_create(cart=cart, tire=tire)
+  instance, created = CartDetail.objects.get_or_create(cart=cart, product=tire.product)
   if not created:
     quantityToCarry = instance.quantity # Existing cart, therefore cache the quantity to carry over
   else:


### PR DESCRIPTION
* Using `save_model` to update `date_effective` failed when adding tires from the `Product` change view (only worked when adding tires from the `Tire` change view)
* Using the `update_date_effective` signal works all the time
* Should add some `UniqueConstraint` on `date_effective` and `product` in the future